### PR TITLE
using existing deltaR, creating seperate File for MassRecoPlots, fixed chrash

### DIFF
--- a/include/TstarTstarHists.h
+++ b/include/TstarTstarHists.h
@@ -2,7 +2,6 @@
 
 #include "UHH2/core/include/Hists.h"
 #include "UHH2/core/include/Event.h"
-#include "UHH2/common/include/ReconstructionHypothesis.h"
 
 namespace uhh2{
 
@@ -22,14 +21,7 @@ public:
     virtual ~TstarTstarHists();
 
   private:
-    uhh2::Event::Handle<ReconstructionHypothesis> h_recohyp_;
-    
-    uhh2::Event::Handle< float > h_M_Tstar_gluon_;
-    uhh2::Event::Handle< float > h_M_Tstar_gamma_;
-    uhh2::Event::Handle< float > h_DeltaR_toplep_ak8jet1_;
-    uhh2::Event::Handle< float > h_DeltaR_tophad_ak8jet1_;
-    uhh2::Event::Handle< float > h_DeltaR_toplep_ak8jet2_;
-    uhh2::Event::Handle< float > h_DeltaR_tophad_ak8jet2_;
+
 };
 
 }

--- a/include/TstarTstarHists.h
+++ b/include/TstarTstarHists.h
@@ -2,6 +2,7 @@
 
 #include "UHH2/core/include/Hists.h"
 #include "UHH2/core/include/Event.h"
+#include "UHH2/common/include/ReconstructionHypothesis.h"
 
 namespace uhh2{
 
@@ -21,6 +22,8 @@ public:
     virtual ~TstarTstarHists();
 
   private:
+    uhh2::Event::Handle<ReconstructionHypothesis> h_recohyp_;
+    
     uhh2::Event::Handle< float > h_M_Tstar_gluon_;
     uhh2::Event::Handle< float > h_M_Tstar_gamma_;
     uhh2::Event::Handle< float > h_DeltaR_toplep_ak8jet1_;

--- a/include/TstarTstarRecoHists.h
+++ b/include/TstarTstarRecoHists.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "UHH2/core/include/Hists.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/common/include/ReconstructionHypothesis.h"
+
+namespace uhh2{
+
+/**  \brief Example class for booking and filling histograms
+ * 
+ * NOTE: This class uses the 'hist' method to retrieve histograms.
+ * This requires a string lookup and is therefore slow if you have
+ * many histograms. Therefore, it is recommended to use histogram
+ * pointers as member data instead, like in 'common/include/ElectronHists.h'.
+ */
+class TstarTstarRecoHists: public uhh2::Hists {
+public:
+    // use the same constructor arguments as Hists for forwarding:
+    TstarTstarRecoHists(uhh2::Context & ctx, const std::string & dirname);
+
+    virtual void fill(const uhh2::Event & ev) override;
+    virtual ~TstarTstarRecoHists();
+
+  private:
+    uhh2::Event::Handle<ReconstructionHypothesis> h_recohyp_;
+    uhh2::Event::Handle< bool > h_is_ttbar_reconstructed_;
+    
+    uhh2::Event::Handle< float > h_M_Tstar_gluon_;
+    uhh2::Event::Handle< float > h_M_Tstar_gamma_;
+    uhh2::Event::Handle< float > h_DeltaR_toplep_ak8jet1_;
+    uhh2::Event::Handle< float > h_DeltaR_tophad_ak8jet1_;
+    uhh2::Event::Handle< float > h_DeltaR_toplep_ak8jet2_;
+    uhh2::Event::Handle< float > h_DeltaR_tophad_ak8jet2_;
+};
+
+}

--- a/macros/DeltaRPlots.C
+++ b/macros/DeltaRPlots.C
@@ -1,0 +1,45 @@
+// Efficiency histograms for trigger related studies
+// author: A.Karavdina (changes by F.Labe)
+// date: 24.09.2019
+// Run it with following command:
+// root -l -b -q photonSelecPlots.C
+
+void TstarMassPlots(TString filename="uhh2.AnalysisModuleRunner.MC.MC_TstarTstarToTgammaTgluon_M-1500_Run2016v3.root", TString label="TstarTstarToTgammaTgluon_M-1500_Run2016v3", TString subpath="AfterMatching",TString histname="XXXXX"){
+  gStyle->SetOptFit(0);
+  gStyle->SetOptStat(0);
+  gStyle->SetTitleSize(0.06,"x");  
+  gStyle->SetTitleSize(0.06,"y");
+  gStyle->SetLabelSize(0.05,"x");  
+  gStyle->SetLabelSize(0.05,"y");
+  gStyle->SetLabelSize(0.05,"z");
+  gStyle->SetPalette(55);
+
+  gStyle->SetPadTopMargin(0.05);
+  gStyle->SetPadBottomMargin(0.13);
+  gStyle->SetPadLeftMargin(0.18);
+  gStyle->SetPadRightMargin(0.17);
+
+  gROOT->ForceStyle();
+  Double_t w = 1200;
+  Double_t h = 600;
+
+  //TODO: should use some kind of for loop if this is actually used in any way!
+  //Files after selection
+  
+  TString path = "/nfs/dust/cms/user/flabe/CMSSW/TstarTstar/102X_v1/Preselection/RunII_2016_MuonHihjPtId_mvaPhoIDwp90Fall17_nonIsoandIsoHLT_addTTBarRECO/semileptonic/old/";
+  
+  TCanvas *c1_hist = new TCanvas("chist", "c", w, h);
+
+  TFile *input = TFile::Open(path+filename);
+  TH1D *hist = (TH1D*)input->Get(subpath+"/"+histname);//histogram
+  if(!hist) cout<<"Hist is empty"<<endl;;
+  hist->GetXaxis()->SetTitle("#DeltaR");
+  hist->GetYaxis()->SetTitle("events");
+  hist->SetTitle("#DeltaR between AK8 and closest Jet used in ttbar Reco");
+  hist->SetMarkerStyle(20);
+  hist->SetMarkerColor(1);
+  hist->SetLineColor(1);
+  hist->Draw("hist");
+ 
+  c1_hist->SaveAs("DeltaR_"+label+"_"+subpath+"_"+histname+"XXXXX.pdf");
+}

--- a/src/TstarTstarHists.cxx
+++ b/src/TstarTstarHists.cxx
@@ -76,28 +76,6 @@ TstarTstarHists::TstarTstarHists(Context & ctx, const string & dirname): Hists(c
   book<TH1F>("pt_MET", "missing E_{T} [GeV]", 100, 0, 2000);
   book<TH1F>("pt_ST_jets", "S_{T}^{jets}=#sum_{i}|AK4 p^{i}_{T}| [GeV/c]", 100, 10, 4000);
 
-  //M_Tstar
-  h_M_Tstar_gluon_ = ctx.get_handle< float >("M_Tstar_gluon");
-  h_M_Tstar_gamma_ = ctx.get_handle< float >("M_Tstar_gamma");
-  book<TH1F>("M_Tstar_gluon", "M_{T^{*}_{g}} [GeV]", 30, 0, 3000);
-  book<TH1F>("M_Tstar_gamma", "M_{T^{*}_{#gamma}} [GeV]", 30, 0, 3000);
-
-  //Delta_R
-  h_DeltaR_toplep_ak8jet1_ = ctx.get_handle< float >("DeltaR_toplep_ak8jet1");
-  h_DeltaR_tophad_ak8jet1_ = ctx.get_handle< float >("DeltaR_tophad_ak8jet1");
-  h_DeltaR_toplep_ak8jet2_ = ctx.get_handle< float >("DeltaR_toplep_ak8jet2");
-  h_DeltaR_tophad_ak8jet2_ = ctx.get_handle< float >("DeltaR_tophad_ak8jet2");
-  h_recohyp_ = ctx.get_handle<ReconstructionHypothesis>("TTbarReconstruction_best");
-  
-  book<TH1F>("DeltaR_toplep_ak8jet1", "DeltaR_toplep_ak8jet1", 40, 0, 4);
-  book<TH1F>("DeltaR_tophad_ak8jet1", "DeltaR_tophad_ak8jet1", 40, 0, 4);
-  book<TH1F>("DeltaR_toplep_ak8jet2", "DeltaR_toplep_ak8jet2", 40, 0, 4);
-  book<TH1F>("DeltaR_tophad_ak8jet2", "DeltaR_tophad_ak8jet2", 40, 0, 4);
-
-  book<TH1F>("DeltaR_toplep_gamma", "DeltaR_toplep_gamma", 40, 0, 4);
-  book<TH1F>("DeltaR_tophad_gamma", "DeltaR_tophad_gamma", 40, 0, 4);
-  book<TH1F>("DeltaR_gamma_ak8jet1", "DeltaR_gamma_ak8jet1", 40, 0, 4);
-  book<TH1F>("DeltaR_gamma_ak8jet2", "DeltaR_gamma_ak8jet2", 40, 0, 4);
 }
 
 
@@ -201,34 +179,6 @@ void TstarTstarHists::fill(const Event & event){
   double st_jets = 0.;
   for(const auto & jet : *jets) st_jets += jet.pt();
   hist("pt_ST_jets")->Fill(st_jets, weight);
-
-  hist("M_Tstar_gluon")->Fill(event.get(h_M_Tstar_gluon_), weight);
-  hist("M_Tstar_gamma")->Fill(event.get(h_M_Tstar_gamma_), weight);
-
-  //TODO Remove Handles, calculate this here!
-  float val_ = event.get(h_DeltaR_toplep_ak8jet1_);
-  float binwidth_ = hist("DeltaR_toplep_ak8jet1")->GetXaxis()->GetBinWidth( hist("DeltaR_toplep_ak8jet1")->GetXaxis()->FindBin(val_) );
-  hist("DeltaR_toplep_ak8jet1")->Fill(val_, weight / binwidth_);
-
-  val_ = event.get(h_DeltaR_tophad_ak8jet1_);
-  binwidth_ = hist("DeltaR_tophad_ak8jet1")->GetXaxis()->GetBinWidth( hist("DeltaR_tophad_ak8jet1")->GetXaxis()->FindBin(val_) );
-  hist("DeltaR_tophad_ak8jet1")->Fill(val_, weight / binwidth_);
-
-  val_ = event.get(h_DeltaR_toplep_ak8jet2_);
-  binwidth_ = hist("DeltaR_toplep_ak8jet2")->GetXaxis()->GetBinWidth( hist("DeltaR_toplep_ak8jet2")->GetXaxis()->FindBin(val_) );
-  hist("DeltaR_toplep_ak8jet2")->Fill(val_, weight / binwidth_);
-
-  val_ = event.get(h_DeltaR_tophad_ak8jet2_);
-  binwidth_ = hist("DeltaR_tophad_ak8jet2")->GetXaxis()->GetBinWidth( hist("DeltaR_tophad_ak8jet2")->GetXaxis()->FindBin(val_) );
-  hist("DeltaR_tophad_ak8jet2")->Fill(val_, weight / binwidth_);
-
-  //TODO All other DeltaRs
-  ReconstructionHypothesis hyp = event.get(h_recohyp_);
-  hist("DeltaR_toplep_gamma")->Fill(0., weight);
-  hist("DeltaR_tophad_gamma")->Fill(0., weight);
-  if(event.topjets->size()>0 && event.photons->size()>0){hist("DeltaR_gamma_ak8jet1")->Fill( deltaR(event.photons->at(0), event.topjets->at(0)) , weight);}
-  if(event.topjets->size()>1 && event.photons->size()>0){hist("DeltaR_gamma_ak8jet2")->Fill( deltaR(event.photons->at(0), event.topjets->at(1)) , weight);}
-
 
 }
 

--- a/src/TstarTstarHists.cxx
+++ b/src/TstarTstarHists.cxx
@@ -87,10 +87,17 @@ TstarTstarHists::TstarTstarHists(Context & ctx, const string & dirname): Hists(c
   h_DeltaR_tophad_ak8jet1_ = ctx.get_handle< float >("DeltaR_tophad_ak8jet1");
   h_DeltaR_toplep_ak8jet2_ = ctx.get_handle< float >("DeltaR_toplep_ak8jet2");
   h_DeltaR_tophad_ak8jet2_ = ctx.get_handle< float >("DeltaR_tophad_ak8jet2");
+  h_recohyp_ = ctx.get_handle<ReconstructionHypothesis>("TTbarReconstruction_best");
+  
   book<TH1F>("DeltaR_toplep_ak8jet1", "DeltaR_toplep_ak8jet1", 40, 0, 4);
   book<TH1F>("DeltaR_tophad_ak8jet1", "DeltaR_tophad_ak8jet1", 40, 0, 4);
   book<TH1F>("DeltaR_toplep_ak8jet2", "DeltaR_toplep_ak8jet2", 40, 0, 4);
   book<TH1F>("DeltaR_tophad_ak8jet2", "DeltaR_tophad_ak8jet2", 40, 0, 4);
+
+  book<TH1F>("DeltaR_toplep_gamma", "DeltaR_toplep_gamma", 40, 0, 4);
+  book<TH1F>("DeltaR_tophad_gamma", "DeltaR_tophad_gamma", 40, 0, 4);
+  book<TH1F>("DeltaR_gamma_ak8jet1", "DeltaR_gamma_ak8jet1", 40, 0, 4);
+  book<TH1F>("DeltaR_gamma_ak8jet2", "DeltaR_gamma_ak8jet2", 40, 0, 4);
 }
 
 
@@ -198,6 +205,7 @@ void TstarTstarHists::fill(const Event & event){
   hist("M_Tstar_gluon")->Fill(event.get(h_M_Tstar_gluon_), weight);
   hist("M_Tstar_gamma")->Fill(event.get(h_M_Tstar_gamma_), weight);
 
+  //TODO Remove Handles, calculate this here!
   float val_ = event.get(h_DeltaR_toplep_ak8jet1_);
   float binwidth_ = hist("DeltaR_toplep_ak8jet1")->GetXaxis()->GetBinWidth( hist("DeltaR_toplep_ak8jet1")->GetXaxis()->FindBin(val_) );
   hist("DeltaR_toplep_ak8jet1")->Fill(val_, weight / binwidth_);
@@ -213,6 +221,14 @@ void TstarTstarHists::fill(const Event & event){
   val_ = event.get(h_DeltaR_tophad_ak8jet2_);
   binwidth_ = hist("DeltaR_tophad_ak8jet2")->GetXaxis()->GetBinWidth( hist("DeltaR_tophad_ak8jet2")->GetXaxis()->FindBin(val_) );
   hist("DeltaR_tophad_ak8jet2")->Fill(val_, weight / binwidth_);
+
+  //TODO All other DeltaRs
+  ReconstructionHypothesis hyp = event.get(h_recohyp_);
+  hist("DeltaR_toplep_gamma")->Fill(0., weight);
+  hist("DeltaR_tophad_gamma")->Fill(0., weight);
+  if(event.topjets->size()>0 && event.photons->size()>0){hist("DeltaR_gamma_ak8jet1")->Fill( deltaR(event.photons->at(0), event.topjets->at(0)) , weight);}
+  if(event.topjets->size()>1 && event.photons->size()>0){hist("DeltaR_gamma_ak8jet2")->Fill( deltaR(event.photons->at(0), event.topjets->at(1)) , weight);}
+
 
 }
 

--- a/src/TstarTstarMCStudyModule.cxx
+++ b/src/TstarTstarMCStudyModule.cxx
@@ -13,6 +13,7 @@
 #include <UHH2/common/include/TriggerSelection.h>
 #include "UHH2/TstarTstar/include/TstarTstarSelections.h"
 #include "UHH2/TstarTstar/include/TstarTstarHists.h"
+#include "UHH2/TstarTstar/include/TstarTstarRecoHists.h"
 #include "UHH2/TstarTstar/include/TstarTstarGenHists.h"
 #include "UHH2/TstarTstar/include/TstarTstarGenRecoMatchedHists.h"
 #include "UHH2/TstarTstar/include/TstarTstarReconstructionModules.h"
@@ -66,11 +67,12 @@ private:
   std::unique_ptr<Hists> h_semilepttbarmatch_triggerSingleJet_genreco, h_semilepttbarmatch_triggerSingleLeptonMu_genreco, h_semilepttbarmatch_triggerSingleLeptonEle_genreco, h_semilepttbarmatch_triggerHT_genreco, h_semilepttbarmatch_triggerPFHT_genreco;
   std::unique_ptr<Hists> h_semilepttbarmatch_triggerSingleJet_genreco_mu, h_semilepttbarmatch_triggerHT_genreco_mu, h_semilepttbarmatch_triggerPFHT_genreco_mu;
   std::unique_ptr<Hists> h_semilepttbarmatch_triggerSingleJet_genreco_ele, h_semilepttbarmatch_triggerHT_genreco_ele, h_semilepttbarmatch_triggerPFHT_genreco_ele;
-  std::unique_ptr<Hists> h_After_ttbar_Reco, h_After_TstarTstar_Reco, h_After_TstarTstar_Reco_match;
+  std::unique_ptr<Hists> h_After_TstarTstar_Reco, h_After_TstarTstar_Reco_match;
+  std::unique_ptr<Hists> h_RecoPlots_After_ttbar, h_RecoPlots_After_TstarTstar, h_RecoPlots_After_TstarTstar_match;
   
   bool isTrigger = false;
-  //bool debug = true;
-  bool debug = false;
+  bool debug = true;
+  //bool debug = false;
   std::unique_ptr<uhh2::AnalysisModule> reco_primlep;
   std::unique_ptr<uhh2::AnalysisModule> ttbar_reco;
   std::unique_ptr<ttbarChi2Discriminator> ttbar_discriminator;
@@ -81,11 +83,6 @@ private:
   uhh2::Event::Handle<ReconstructionHypothesis> h_recohyp;
   uhh2::Event::Handle<float> h_M_Tstar_gluon;
   uhh2::Event::Handle<float> h_M_Tstar_gamma;
-
-  uhh2::Event::Handle<float> h_DeltaR_toplep_ak8jet1;
-  uhh2::Event::Handle<float> h_DeltaR_tophad_ak8jet1;
-  uhh2::Event::Handle<float> h_DeltaR_toplep_ak8jet2;
-  uhh2::Event::Handle<float> h_DeltaR_tophad_ak8jet2;
 };
 
 TstarTstarMCStudyModule::TstarTstarMCStudyModule(Context & ctx){
@@ -205,9 +202,13 @@ TstarTstarMCStudyModule::TstarTstarMCStudyModule(Context & ctx){
     h_semilepttbarmatch_triggerSingleLeptonMu_genreco.reset(new TstarTstarGenRecoMatchedHists(ctx, "SemiLepTTBarMatchGENRECO_triggerSingleLeptonMu"));
     h_semilepttbarmatch_triggerSingleLeptonEle_genreco.reset(new TstarTstarGenRecoMatchedHists(ctx, "SemiLepTTBarMatchGENRECO_triggerSingleLeptonEle"));
 
-    h_After_ttbar_Reco.reset(new TstarTstarHists(ctx, "After_ttbar_Reco"));
     h_After_TstarTstar_Reco.reset(new TstarTstarHists(ctx, "After_TstarTstar_Reco"));
     h_After_TstarTstar_Reco_match.reset(new TstarTstarHists(ctx, "After_TstarTstar_Reco_match"));
+
+    h_RecoPlots_After_ttbar.reset(new TstarTstarRecoHists(ctx, "RecoPlots_After_ttbar"));
+    h_RecoPlots_After_TstarTstar.reset(new TstarTstarRecoHists(ctx, "RecoPlots_After_TstarTstar"));
+    h_RecoPlots_After_TstarTstar_match.reset(new TstarTstarRecoHists(ctx, "RecoPlots_After_TstarTstar_match"));
+
 
     //4. Set up ttbar reconstruction
     const std::string ttbar_hyps_label("TTbarReconstruction");
@@ -227,11 +228,6 @@ TstarTstarMCStudyModule::TstarTstarMCStudyModule(Context & ctx){
 
     TstarTstar_reco.reset(new TstarTstar_Reconstruction(ctx));
 
-    h_DeltaR_toplep_ak8jet1 = ctx.get_handle< float >("DeltaR_toplep_ak8jet1");
-    h_DeltaR_tophad_ak8jet1 = ctx.get_handle< float >("DeltaR_tophad_ak8jet1");
-    h_DeltaR_toplep_ak8jet2 = ctx.get_handle< float >("DeltaR_toplep_ak8jet2");
-    h_DeltaR_tophad_ak8jet2 = ctx.get_handle< float >("DeltaR_tophad_ak8jet2");
-
 }
 
 
@@ -249,11 +245,7 @@ bool TstarTstarMCStudyModule::process(Event & event) {
   event.set(h_M_Tstar_gluon, 0.);
   event.set(h_M_Tstar_gamma, 0.);
   event.set(h_is_ttbar_reconstructed, false);
-
-  event.set(h_DeltaR_toplep_ak8jet1, 999);
-  event.set(h_DeltaR_tophad_ak8jet1, 999);
-  event.set(h_DeltaR_toplep_ak8jet2, 999);
-  event.set(h_DeltaR_tophad_ak8jet2, 999);
+  event.set(h_recohyp, ReconstructionHypothesis());
 
   if(debug){cout << "Finished initialization of Handle Variables" << endl;}
 
@@ -390,49 +382,18 @@ bool TstarTstarMCStudyModule::process(Event & event) {
   if(debug) {cout << "Finished. Finding best Hypothesis..."<< endl;}	\
   ttbar_discriminator->process(event);
 
+  h_RecoPlots_After_ttbar->fill(event);
+
   ReconstructionHypothesis hyp = event.get(h_recohyp);  
 
-  //### BEGIN Calculate DeltaRs
-  float DeltaR_min = 9999;
-  for (uint i = 0; i < hyp.tophad_jets().size(); i++){
-    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(0)); 
-    if(DeltaR_new < DeltaR_min){
-      DeltaR_min = DeltaR_new;
-    }
-  }
-  event.set(h_DeltaR_tophad_ak8jet1, DeltaR_min);
-    
-  for (uint i = 0; i < hyp.toplep_jets().size(); i++){
-    float DeltaR_new = deltaR(hyp.toplep_jets().at(i), event.topjets->at(0)); 
-    if(DeltaR_new < DeltaR_min){
-      DeltaR_min = DeltaR_new;
-    }
-  }
-  event.set(h_DeltaR_toplep_ak8jet1, DeltaR_min);
-
-  for (uint i = 0; i < hyp.tophad_jets().size(); i++){
-    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(1)); 
-    if(DeltaR_new < DeltaR_min){
-      DeltaR_min = DeltaR_new;
-    }
-  }
-  event.set(h_DeltaR_tophad_ak8jet2, DeltaR_min);
-
-  for (uint i = 0; i < hyp.toplep_jets().size(); i++){
-    float DeltaR_new = deltaR(hyp.toplep_jets().at(i), event.topjets->at(1)); 
-    if(DeltaR_new < DeltaR_min){
-      DeltaR_min = DeltaR_new;
-    }
-  }
-  event.set(h_DeltaR_toplep_ak8jet2, DeltaR_min);
-  //### END Calculate DeltaR
-
-  h_After_ttbar_Reco->fill(event);
-  
   if(event.get(h_is_ttbar_reconstructed)){
     if(TstarTstar_reco->process(event)){
       h_After_TstarTstar_Reco->fill(event);
-      if(pass_ttbarsemilep){h_After_TstarTstar_Reco_match->fill(event);} //Check same plots for matching
+      h_RecoPlots_After_TstarTstar->fill(event);
+      if(pass_ttbarsemilep){   //Check same plots for matching
+	h_After_TstarTstar_Reco_match->fill(event);
+	h_RecoPlots_After_TstarTstar_match->fill(event);
+      }
     }
   }
   else{

--- a/src/TstarTstarMCStudyModule.cxx
+++ b/src/TstarTstarMCStudyModule.cxx
@@ -71,8 +71,8 @@ private:
   std::unique_ptr<Hists> h_RecoPlots_After_ttbar, h_RecoPlots_After_TstarTstar, h_RecoPlots_After_TstarTstar_match;
   
   bool isTrigger = false;
-  bool debug = true;
-  //bool debug = false;
+  //bool debug = true;
+  bool debug = false;
   std::unique_ptr<uhh2::AnalysisModule> reco_primlep;
   std::unique_ptr<uhh2::AnalysisModule> ttbar_reco;
   std::unique_ptr<ttbarChi2Discriminator> ttbar_discriminator;
@@ -382,11 +382,10 @@ bool TstarTstarMCStudyModule::process(Event & event) {
   if(debug) {cout << "Finished. Finding best Hypothesis..."<< endl;}	\
   ttbar_discriminator->process(event);
 
-  h_RecoPlots_After_ttbar->fill(event);
-
   ReconstructionHypothesis hyp = event.get(h_recohyp);  
 
   if(event.get(h_is_ttbar_reconstructed)){
+    h_RecoPlots_After_ttbar->fill(event);
     if(TstarTstar_reco->process(event)){
       h_After_TstarTstar_Reco->fill(event);
       h_RecoPlots_After_TstarTstar->fill(event);

--- a/src/TstarTstarRecoHists.cxx
+++ b/src/TstarTstarRecoHists.cxx
@@ -11,7 +11,6 @@ using namespace uhh2;
 
 TstarTstarRecoHists::TstarTstarRecoHists(Context & ctx, const string & dirname): Hists(ctx, dirname){
   // book all histograms here
-  // jets
 
   //M_Tstar
   h_M_Tstar_gluon_ = ctx.get_handle< float >("M_Tstar_gluon");
@@ -20,17 +19,13 @@ TstarTstarRecoHists::TstarTstarRecoHists(Context & ctx, const string & dirname):
   book<TH1F>("M_Tstar_gamma", "M_{T^{*}_{#gamma}} [GeV]", 30, 0, 3000);
 
   //Delta_R
-  h_DeltaR_toplep_ak8jet1_ = ctx.get_handle< float >("DeltaR_toplep_ak8jet1");
-  h_DeltaR_tophad_ak8jet1_ = ctx.get_handle< float >("DeltaR_tophad_ak8jet1");
-  h_DeltaR_toplep_ak8jet2_ = ctx.get_handle< float >("DeltaR_toplep_ak8jet2");
-  h_DeltaR_tophad_ak8jet2_ = ctx.get_handle< float >("DeltaR_tophad_ak8jet2");
   h_recohyp_ = ctx.get_handle<ReconstructionHypothesis>("TTbarReconstruction_best");
   h_is_ttbar_reconstructed_ = ctx.get_handle< bool >("is_ttbar_reconstructed_chi2");
   
-  book<TH1F>("DeltaR_toplep_ak8jet1", "DeltaR_toplep_ak8jet1", 40, 0, 4);
-  book<TH1F>("DeltaR_tophad_ak8jet1", "DeltaR_tophad_ak8jet1", 40, 0, 4);
-  book<TH1F>("DeltaR_toplep_ak8jet2", "DeltaR_toplep_ak8jet2", 40, 0, 4);
-  book<TH1F>("DeltaR_tophad_ak8jet2", "DeltaR_tophad_ak8jet2", 40, 0, 4);
+  book<TH1F>("DeltaR_closest_toplepjet_ak8jet1", "DeltaR_toplepjet_ak8jet1", 40, 0, 4);
+  book<TH1F>("DeltaR_closest_tophadjet_ak8jet1", "DeltaR_tophadjet_ak8jet1", 40, 0, 4);
+  book<TH1F>("DeltaR_closest_toplepjet_ak8jet2", "DeltaR_toplepjet_ak8jet2", 40, 0, 4);
+  book<TH1F>("DeltaR_closest_tophadjet_ak8jet2", "DeltaR_tophadjet_ak8jet2", 40, 0, 4);
 
   book<TH1F>("DeltaR_toplep_gamma", "DeltaR_toplep_gamma", 40, 0, 4);
   book<TH1F>("DeltaR_tophad_gamma", "DeltaR_tophad_gamma", 40, 0, 4);
@@ -54,41 +49,44 @@ void TstarTstarRecoHists::fill(const Event & event){
   ReconstructionHypothesis hyp = event.get(h_recohyp_);
 
   float DeltaR_min = 9999;
-  for (uint i = 0; i < hyp.tophad_jets().size(); i++){
-    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(0)); 
-    if(DeltaR_new < DeltaR_min){
-      DeltaR_min = DeltaR_new;
+  if(event.topjets->size()>0){
+    for (uint i = 0; i < hyp.toplep_jets().size(); i++){
+      float DeltaR_new = deltaR(hyp.toplep_jets().at(i), event.topjets->at(0)); 
+      if(DeltaR_new < DeltaR_min){
+	DeltaR_min = DeltaR_new;
+      }
     }
-  }
-  hist("DeltaR_toplep_ak8jet1")->Fill(DeltaR_min, weight);
-    
-  DeltaR_min = 9999;
-  for (uint i = 0; i < hyp.toplep_jets().size(); i++){
-    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(0)); 
-    if(DeltaR_new < DeltaR_min){
-      DeltaR_min = DeltaR_new;
+    hist("DeltaR_closest_toplepjet_ak8jet1")->Fill(DeltaR_min, weight);
+
+    DeltaR_min = 9999;
+    for (uint i = 0; i < hyp.tophad_jets().size(); i++){
+      float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(0)); 
+      if(DeltaR_new < DeltaR_min){
+	DeltaR_min = DeltaR_new;
+      }
     }
+    hist("DeltaR_closest_tophadjet_ak8jet1")->Fill(DeltaR_min, weight);
   }
-  hist("DeltaR_tophad_ak8jet1")->Fill(DeltaR_min, weight);
-    
-  DeltaR_min = 9999;
-  for (uint i = 0; i < hyp.tophad_jets().size(); i++){
-    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(1)); 
-    if(DeltaR_new < DeltaR_min){
-      DeltaR_min = DeltaR_new;
+  if(event.topjets->size()>1){
+    DeltaR_min = 9999;
+    for (uint i = 0; i < hyp.toplep_jets().size(); i++){
+      float DeltaR_new = deltaR(hyp.toplep_jets().at(i), event.topjets->at(1)); 
+      if(DeltaR_new < DeltaR_min){
+	DeltaR_min = DeltaR_new;
+      }
     }
-  }
-  hist("DeltaR_toplep_ak8jet2")->Fill(DeltaR_min, weight);
-    
-  DeltaR_min = 9999;
-  for (uint i = 0; i < hyp.toplep_jets().size(); i++){
-    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(1)); 
-    if(DeltaR_new < DeltaR_min){
-      DeltaR_min = DeltaR_new;
-    }
-  }
-  hist("DeltaR_tophad_ak8jet2")->Fill(DeltaR_min, weight);
+    hist("DeltaR_closest_toplepjet_ak8jet2")->Fill(DeltaR_min, weight);
   
+    DeltaR_min = 9999;
+    for (uint i = 0; i < hyp.tophad_jets().size(); i++){
+      float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(1)); 
+      if(DeltaR_new < DeltaR_min){
+	DeltaR_min = DeltaR_new;
+      }
+    }
+    hist("DeltaR_closest_tophadjet_ak8jet2")->Fill(DeltaR_min, weight);
+  }
+
   //TODO All other DeltaRs
   if(event.photons->size()>0){hist("DeltaR_toplep_gamma")->Fill( deltaR(hyp.toplep_v4(), event.photons->at(0)), weight);}
   if(event.photons->size()>0){hist("DeltaR_tophad_gamma")->Fill( deltaR(hyp.tophad_v4(), event.photons->at(0)) , weight);}

--- a/src/TstarTstarRecoHists.cxx
+++ b/src/TstarTstarRecoHists.cxx
@@ -1,0 +1,101 @@
+#include "UHH2/TstarTstar/include/TstarTstarRecoHists.h"
+#include "UHH2/core/include/Event.h"
+
+#include "TH1F.h"
+#include "TH2F.h"
+#include <iostream>
+
+using namespace std;
+using namespace uhh2;
+//using namespace uhh2examples;
+
+TstarTstarRecoHists::TstarTstarRecoHists(Context & ctx, const string & dirname): Hists(ctx, dirname){
+  // book all histograms here
+  // jets
+
+  //M_Tstar
+  h_M_Tstar_gluon_ = ctx.get_handle< float >("M_Tstar_gluon");
+  h_M_Tstar_gamma_ = ctx.get_handle< float >("M_Tstar_gamma");
+  book<TH1F>("M_Tstar_gluon", "M_{T^{*}_{g}} [GeV]", 30, 0, 3000);
+  book<TH1F>("M_Tstar_gamma", "M_{T^{*}_{#gamma}} [GeV]", 30, 0, 3000);
+
+  //Delta_R
+  h_DeltaR_toplep_ak8jet1_ = ctx.get_handle< float >("DeltaR_toplep_ak8jet1");
+  h_DeltaR_tophad_ak8jet1_ = ctx.get_handle< float >("DeltaR_tophad_ak8jet1");
+  h_DeltaR_toplep_ak8jet2_ = ctx.get_handle< float >("DeltaR_toplep_ak8jet2");
+  h_DeltaR_tophad_ak8jet2_ = ctx.get_handle< float >("DeltaR_tophad_ak8jet2");
+  h_recohyp_ = ctx.get_handle<ReconstructionHypothesis>("TTbarReconstruction_best");
+  h_is_ttbar_reconstructed_ = ctx.get_handle< bool >("is_ttbar_reconstructed_chi2");
+  
+  book<TH1F>("DeltaR_toplep_ak8jet1", "DeltaR_toplep_ak8jet1", 40, 0, 4);
+  book<TH1F>("DeltaR_tophad_ak8jet1", "DeltaR_tophad_ak8jet1", 40, 0, 4);
+  book<TH1F>("DeltaR_toplep_ak8jet2", "DeltaR_toplep_ak8jet2", 40, 0, 4);
+  book<TH1F>("DeltaR_tophad_ak8jet2", "DeltaR_tophad_ak8jet2", 40, 0, 4);
+
+  book<TH1F>("DeltaR_toplep_gamma", "DeltaR_toplep_gamma", 40, 0, 4);
+  book<TH1F>("DeltaR_tophad_gamma", "DeltaR_tophad_gamma", 40, 0, 4);
+  book<TH1F>("DeltaR_gamma_ak8jet1", "DeltaR_gamma_ak8jet1", 40, 0, 4);
+  book<TH1F>("DeltaR_gamma_ak8jet2", "DeltaR_gamma_ak8jet2", 40, 0, 4);
+}
+
+
+void TstarTstarRecoHists::fill(const Event & event){
+  // fill the histograms. Please note the comments in the header file:
+  // 'hist' is used here a lot for simplicity, but it will be rather
+  // slow when you have many histograms; therefore, better
+  // use histogram pointers as members as in 'UHH2/common/include/ElectronHists.h'
+  
+  // Don't forget to always use the weight when filling.
+  double weight = event.weight;
+  
+  hist("M_Tstar_gluon")->Fill(event.get(h_M_Tstar_gluon_), weight);
+  hist("M_Tstar_gamma")->Fill(event.get(h_M_Tstar_gamma_), weight);
+
+  ReconstructionHypothesis hyp = event.get(h_recohyp_);
+
+  float DeltaR_min = 9999;
+  for (uint i = 0; i < hyp.tophad_jets().size(); i++){
+    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(0)); 
+    if(DeltaR_new < DeltaR_min){
+      DeltaR_min = DeltaR_new;
+    }
+  }
+  hist("DeltaR_toplep_ak8jet1")->Fill(DeltaR_min, weight);
+    
+  DeltaR_min = 9999;
+  for (uint i = 0; i < hyp.toplep_jets().size(); i++){
+    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(0)); 
+    if(DeltaR_new < DeltaR_min){
+      DeltaR_min = DeltaR_new;
+    }
+  }
+  hist("DeltaR_tophad_ak8jet1")->Fill(DeltaR_min, weight);
+    
+  DeltaR_min = 9999;
+  for (uint i = 0; i < hyp.tophad_jets().size(); i++){
+    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(1)); 
+    if(DeltaR_new < DeltaR_min){
+      DeltaR_min = DeltaR_new;
+    }
+  }
+  hist("DeltaR_toplep_ak8jet2")->Fill(DeltaR_min, weight);
+    
+  DeltaR_min = 9999;
+  for (uint i = 0; i < hyp.toplep_jets().size(); i++){
+    float DeltaR_new = deltaR(hyp.tophad_jets().at(i), event.topjets->at(1)); 
+    if(DeltaR_new < DeltaR_min){
+      DeltaR_min = DeltaR_new;
+    }
+  }
+  hist("DeltaR_tophad_ak8jet2")->Fill(DeltaR_min, weight);
+  
+  //TODO All other DeltaRs
+  if(event.photons->size()>0){hist("DeltaR_toplep_gamma")->Fill( deltaR(hyp.toplep_v4(), event.photons->at(0)), weight);}
+  if(event.photons->size()>0){hist("DeltaR_tophad_gamma")->Fill( deltaR(hyp.tophad_v4(), event.photons->at(0)) , weight);}
+  if(event.topjets->size()>0 && event.photons->size()>0){hist("DeltaR_gamma_ak8jet1")->Fill( deltaR(event.photons->at(0), event.topjets->at(0)) , weight);}
+  if(event.topjets->size()>1 && event.photons->size()>0){hist("DeltaR_gamma_ak8jet2")->Fill( deltaR(event.photons->at(0), event.topjets->at(1)) , weight);}
+
+
+}
+
+TstarTstarRecoHists::~TstarTstarRecoHists(){}

--- a/src/TstarTstarReconstructionModules.cxx
+++ b/src/TstarTstarReconstructionModules.cxx
@@ -15,13 +15,6 @@ namespace {
 
 }
 
-//Method to calculate DeltaR. Will change to passing two Particles instead of four floats.
-float calculateDeltaR(float eta1_, float eta2_, float phi1_, float phi2_){
-  float Deta_ = eta1_ - eta2_;
-  float Dphi_ = phi1_ - phi2_;
-  return sqrt( pow(Deta_, 2) + pow(Dphi_, 2) );
-}
-
 ttbarChi2Discriminator::ttbarChi2Discriminator(uhh2::Context& ctx){
 
   //Getting needed Handles
@@ -176,13 +169,13 @@ bool TstarTstar_Reconstruction::process(uhh2::Event& event){
 
   for(uint j = 0; j < all_topjets_.size(); j++){
     for (uint i = 0; i < hyp.tophad_jets().size(); i++){
-      float DeltaR_new = calculateDeltaR(hyp.tophad_jets().at(i).eta(), all_topjets_.at(j).eta(), hyp.tophad_jets().at(i).phi(), all_topjets_.at(j).phi()); 
+      float DeltaR_new = deltaR(hyp.tophad_jets().at(i), all_topjets_.at(j)); 
       if(DeltaR_new < DeltaR_min){
 	DeltaR_min = DeltaR_new;
       }
     }
     for (uint i = 0; i < hyp.toplep_jets().size(); i++){
-      float DeltaR_new = calculateDeltaR(hyp.toplep_jets().at(i).eta(), all_topjets_.at(j).eta(), hyp.toplep_jets().at(i).phi(), all_topjets_.at(j).phi()); 
+      float DeltaR_new = deltaR(hyp.toplep_jets().at(i), all_topjets_.at(j)); 
       if(DeltaR_new < DeltaR_min){
 	DeltaR_min = DeltaR_new;
       }


### PR DESCRIPTION
1) deltaR exists, no need to use own function calculateDeltaR, so removed that and switched to deltaR everywhere.

2) Recoplots (like TstarTstar Masses etc) were calculated for each selection step, this is unnecessary.
Now seperate Histogram file that is only called after the Reconstruction.

3) lower mass point files have events with less than 2 AK8Jets, this crashed in TstarTstarRecoHists.cxx. Fixed.